### PR TITLE
Bump Mapbox Draw to latest version 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,2380 @@
 {
   "name": "mapbox-gl-draw-split-polygon-mode",
-  "version": "0.1.0",
-  "lockfileVersion": 1,
+  "version": "1.0.2",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "mapbox-gl-draw-split-polygon-mode",
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/turf": "5.1.6"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "11.0.2",
+        "@rollup/plugin-inject": "4.0.1",
+        "@rollup/plugin-node-resolve": "7.1.1",
+        "rollup": "^1.27.14",
+        "rollup-plugin-terser": "^7.0.2"
+      },
+      "peerDependencies": {
+        "@mapbox/mapbox-gl-draw": "1.3.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@mapbox/extent": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
+      "integrity": "sha512-MSoKw3qPceGuupn04sdaJrFeLKvcSETVLZCGS8JA9x6zXQL3FWiKaIXYIZEDXd5jpXpWlRxinCZIN49yRy0C9A==",
+      "peer": true
+    },
+    "node_modules/@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==",
+      "peer": true,
+      "dependencies": {
+        "wgs84": "0.0.0"
+      }
+    },
+    "node_modules/@mapbox/geojson-coords": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz",
+      "integrity": "sha512-YuVzpseee/P1T5BWyeVVPppyfmuXYHFwZHmybkqaMfu4BWlOf2cmMGKj2Rr92MwfSTOCSUA0PAsVGRG8akY0rg==",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/geojson-normalize": "0.0.1",
+        "geojson-flatten": "^1.0.4"
+      }
+    },
+    "node_modules/@mapbox/geojson-extent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-extent/-/geojson-extent-1.0.1.tgz",
+      "integrity": "sha512-hh8LEO3djT4fqfr8sSC6wKt+p0TMiu+KOLMBUiFOyj+zGq7+IXwQGl0ppCVDkyzCewyd9LoGe9zAvDxXrLfhLw==",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/extent": "0.4.0",
+        "@mapbox/geojson-coords": "0.0.2",
+        "rw": "~0.1.4",
+        "traverse": "~0.6.6"
+      },
+      "bin": {
+        "geojson-extent": "bin/geojson-extent"
+      }
+    },
+    "node_modules/@mapbox/geojson-normalize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz",
+      "integrity": "sha512-82V7YHcle8lhgIGqEWwtXYN5cy0QM/OHq3ypGhQTbvHR57DF0vMHMjjVSQKFfVXBe/yWCBZTyOuzvK7DFFnx5Q==",
+      "peer": true,
+      "bin": {
+        "geojson-normalize": "geojson-normalize"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-draw": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.3.0.tgz",
+      "integrity": "sha512-B+KWK+dAgzLHMNyKVuuMRfjeSlQ77MhNLdfpQQpbp3pkhnrdmydDe3ixto1Ua78hktNut0WTrAaD8gYu4PVcjA==",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/geojson-area": "^0.2.2",
+        "@mapbox/geojson-extent": "^1.0.0",
+        "@mapbox/geojson-normalize": "^0.0.1",
+        "@mapbox/point-geometry": "^0.1.0",
+        "hat": "0.0.3",
+        "lodash.isequal": "^4.5.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "peer": true
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.2.tgz",
+      "integrity": "sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.0",
+        "estree-walker": "^1.0.1",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0"
+      }
+    },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.1.tgz",
+      "integrity": "sha512-Rp08zyniSaBpZHh9Zk4vTkJcLWV10S5lm57c5T6QuTrgkkgY5o2LnHRnmF73tXMTTQpY+Y7NR0l48dAJJ7cMRw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.4",
+        "estree-walker": "^1.0.1",
+        "magic-string": "^0.25.5"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
+      "integrity": "sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.6",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.14.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "lineclip": "^1.1.5"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-overlap": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/projection": "^5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/convex": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
+      "dependencies": {
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "skmeans": "0.9.7"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/@turf/collect/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+    },
+    "node_modules/@turf/collect/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/tin": "^5.1.5",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "concaveman": "*"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
+      "dependencies": {
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "*"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/transform-rotate": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/hex-grid": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/point-grid": "^5.1.5",
+        "@turf/square-grid": "^5.1.5",
+        "@turf/triangle-grid": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/length": "^5.1.5",
+        "@turf/line-slice-along": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "@turf/square": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/@turf/mask/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+    },
+    "node_modules/@turf/mask/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
+      "dependencies": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/point-to-line-distance": "^5.1.5",
+        "object-assign": "*"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line/node_modules/@turf/helpers": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+    },
+    "node_modules/@turf/nearest-point-to-line/node_modules/@turf/invariant": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
+      "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+      "dependencies": {
+        "@turf/helpers": "6.x"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line/node_modules/@turf/meta": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "dependencies": {
+        "@turf/helpers": "6.x"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
+      "dependencies": {
+        "@turf/boolean-within": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/nearest-point": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+      "dependencies": {
+        "@turf/bearing": "6.x",
+        "@turf/distance": "6.x",
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/projection": "6.x",
+        "@turf/rhumb-bearing": "6.x",
+        "@turf/rhumb-distance": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/bearing": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.0.1.tgz",
+      "integrity": "sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/clone": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.0.2.tgz",
+      "integrity": "sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==",
+      "dependencies": {
+        "@turf/helpers": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/distance": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
+      "integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/invariant": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
+      "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+      "dependencies": {
+        "@turf/helpers": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "dependencies": {
+        "@turf/helpers": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/projection": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.0.1.tgz",
+      "integrity": "sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==",
+      "dependencies": {
+        "@turf/clone": "6.x",
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/rhumb-bearing": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
+      "integrity": "sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance/node_modules/@turf/rhumb-distance": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz",
+      "integrity": "sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==",
+      "dependencies": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/envelope": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
+      "dependencies": {
+        "@turf/circle": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-arc": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/transform-scale": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
+      "dependencies": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
+      "dependencies": {
+        "@turf/boolean-contains": "^5.1.5",
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
+      "dependencies": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/ellipse": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/points-within-polygon": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "earcut": "^2.0.0"
+      }
+    },
+    "node_modules/@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "dependencies": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "dependencies": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "dependencies": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
+      "dependencies": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
+      "dependencies": {
+        "@turf/along": "5.1.x",
+        "@turf/area": "5.1.x",
+        "@turf/bbox": "5.1.x",
+        "@turf/bbox-clip": "5.1.x",
+        "@turf/bbox-polygon": "5.1.x",
+        "@turf/bearing": "5.1.x",
+        "@turf/bezier-spline": "5.1.x",
+        "@turf/boolean-clockwise": "5.1.x",
+        "@turf/boolean-contains": "5.1.x",
+        "@turf/boolean-crosses": "5.1.x",
+        "@turf/boolean-disjoint": "5.1.x",
+        "@turf/boolean-equal": "5.1.x",
+        "@turf/boolean-overlap": "5.1.x",
+        "@turf/boolean-parallel": "5.1.x",
+        "@turf/boolean-point-in-polygon": "5.1.x",
+        "@turf/boolean-point-on-line": "5.1.x",
+        "@turf/boolean-within": "5.1.x",
+        "@turf/buffer": "5.1.x",
+        "@turf/center": "5.1.x",
+        "@turf/center-mean": "5.1.x",
+        "@turf/center-median": "5.1.x",
+        "@turf/center-of-mass": "5.1.x",
+        "@turf/centroid": "5.1.x",
+        "@turf/circle": "5.1.x",
+        "@turf/clean-coords": "5.1.x",
+        "@turf/clone": "5.1.x",
+        "@turf/clusters": "5.1.x",
+        "@turf/clusters-dbscan": "5.1.x",
+        "@turf/clusters-kmeans": "5.1.x",
+        "@turf/collect": "5.1.x",
+        "@turf/combine": "5.1.x",
+        "@turf/concave": "5.1.x",
+        "@turf/convex": "5.1.x",
+        "@turf/destination": "5.1.x",
+        "@turf/difference": "5.1.x",
+        "@turf/dissolve": "5.1.x",
+        "@turf/distance": "5.1.x",
+        "@turf/ellipse": "5.1.x",
+        "@turf/envelope": "5.1.x",
+        "@turf/explode": "5.1.x",
+        "@turf/flatten": "5.1.x",
+        "@turf/flip": "5.1.x",
+        "@turf/great-circle": "5.1.x",
+        "@turf/helpers": "5.1.x",
+        "@turf/hex-grid": "5.1.x",
+        "@turf/interpolate": "5.1.x",
+        "@turf/intersect": "5.1.x",
+        "@turf/invariant": "5.1.x",
+        "@turf/isobands": "5.1.x",
+        "@turf/isolines": "5.1.x",
+        "@turf/kinks": "5.1.x",
+        "@turf/length": "5.1.x",
+        "@turf/line-arc": "5.1.x",
+        "@turf/line-chunk": "5.1.x",
+        "@turf/line-intersect": "5.1.x",
+        "@turf/line-offset": "5.1.x",
+        "@turf/line-overlap": "5.1.x",
+        "@turf/line-segment": "5.1.x",
+        "@turf/line-slice": "5.1.x",
+        "@turf/line-slice-along": "5.1.x",
+        "@turf/line-split": "5.1.x",
+        "@turf/line-to-polygon": "5.1.x",
+        "@turf/mask": "5.1.x",
+        "@turf/meta": "5.1.x",
+        "@turf/midpoint": "5.1.x",
+        "@turf/nearest-point": "5.1.x",
+        "@turf/nearest-point-on-line": "5.1.x",
+        "@turf/nearest-point-to-line": "5.1.x",
+        "@turf/planepoint": "5.1.x",
+        "@turf/point-grid": "5.1.x",
+        "@turf/point-on-feature": "5.1.x",
+        "@turf/point-to-line-distance": "5.1.x",
+        "@turf/points-within-polygon": "5.1.x",
+        "@turf/polygon-tangents": "5.1.x",
+        "@turf/polygon-to-line": "5.1.x",
+        "@turf/polygonize": "5.1.x",
+        "@turf/projection": "5.1.x",
+        "@turf/random": "5.1.x",
+        "@turf/rewind": "5.1.x",
+        "@turf/rhumb-bearing": "5.1.x",
+        "@turf/rhumb-destination": "5.1.x",
+        "@turf/rhumb-distance": "5.1.x",
+        "@turf/sample": "5.1.x",
+        "@turf/sector": "5.1.x",
+        "@turf/shortest-path": "5.1.x",
+        "@turf/simplify": "5.1.x",
+        "@turf/square": "5.1.x",
+        "@turf/square-grid": "5.1.x",
+        "@turf/standard-deviational-ellipse": "5.1.x",
+        "@turf/tag": "5.1.x",
+        "@turf/tesselate": "5.1.x",
+        "@turf/tin": "5.1.x",
+        "@turf/transform-rotate": "5.1.x",
+        "@turf/transform-scale": "5.1.x",
+        "@turf/transform-translate": "5.1.x",
+        "@turf/triangle-grid": "5.1.x",
+        "@turf/truncate": "5.1.x",
+        "@turf/union": "5.1.x",
+        "@turf/unkink-polygon": "5.1.x",
+        "@turf/voronoi": "5.1.x"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
+      "dependencies": {
+        "@turf/area": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/@turf/unkink-polygon/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+    },
+    "node_modules/@turf/unkink-polygon/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+      "dev": true
+    },
+    "node_modules/@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/concaveman": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.0.tgz",
+      "integrity": "sha512-OcqechF2/kubbffomKqjGEkb0ndlYhEbmyg/fxIGqdfYp5AZjD2Kl5hc97Hh3ngEuHU2314Z4KDbxL7qXGWrQQ==",
+      "dependencies": {
+        "point-in-polygon": "^1.0.1",
+        "rbush": "^3.0.0",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
+    "node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/density-clustering": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
+      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
+    },
+    "node_modules/earcut": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
+      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+    },
+    "node_modules/es-abstract": {
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/geojson-equality": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
+      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "dependencies": {
+        "deep-equal": "^1.0.0"
+      }
+    },
+    "node_modules/geojson-flatten": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.0.4.tgz",
+      "integrity": "sha512-PpscUXxO6dvvhZxtwuqiI5v+1C/IQYPJRMWoQeaF2oohJgfGYSHKVAe8L+yUqF34PH/hmq9JlwmO+juPw+95/Q==",
+      "peer": true,
+      "dependencies": {
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "geojson-flatten": "geojson-flatten"
+      }
+    },
+    "node_modules/geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
+      "dependencies": {
+        "@turf/helpers": "*",
+        "@turf/meta": "*",
+        "rbush": "*"
+      }
+    },
+    "node_modules/get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hat": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "integrity": "sha512-zpImx2GoKXy42fVDSEad2BPKuSQdLcqsCYa48K3zHSzM/ugWuYjLDr8IXxpVuL7uCLHw56eaiLxCRthhOzf5ug==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "peer": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "peer": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+      "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
+      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags/node_modules/es-abstract": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="
+    },
+    "node_modules/rollup": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      }
+    },
+    "node_modules/rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0"
+      }
+    },
+    "node_modules/rw": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
+      "integrity": "sha512-vSj3D96kMcjNyqPcp65wBRIDImGSrUuMxngNNxvw8MQaO+aQ6llzRPH7XcJy5zrpb3wU++045+Uz/IDIM684iw==",
+      "peer": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
+    },
+    "node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.0.tgz",
+      "integrity": "sha512-eopt1Gf7/AQyPhpygdKePTzaet31TvQxXvrf7xYUvD/d8qkCJm4SKPDzu+GHK5ZaYTn8rvttfqaZc3swK21e5g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
+      "peer": true
+    },
+    "node_modules/turf-jsts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
+      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
+    },
+    "node_modules/wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==",
+      "peer": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.4",
@@ -29,6 +2401,70 @@
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@mapbox/extent": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
+      "integrity": "sha512-MSoKw3qPceGuupn04sdaJrFeLKvcSETVLZCGS8JA9x6zXQL3FWiKaIXYIZEDXd5jpXpWlRxinCZIN49yRy0C9A==",
+      "peer": true
+    },
+    "@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==",
+      "peer": true,
+      "requires": {
+        "wgs84": "0.0.0"
+      }
+    },
+    "@mapbox/geojson-coords": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz",
+      "integrity": "sha512-YuVzpseee/P1T5BWyeVVPppyfmuXYHFwZHmybkqaMfu4BWlOf2cmMGKj2Rr92MwfSTOCSUA0PAsVGRG8akY0rg==",
+      "peer": true,
+      "requires": {
+        "@mapbox/geojson-normalize": "0.0.1",
+        "geojson-flatten": "^1.0.4"
+      }
+    },
+    "@mapbox/geojson-extent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-extent/-/geojson-extent-1.0.1.tgz",
+      "integrity": "sha512-hh8LEO3djT4fqfr8sSC6wKt+p0TMiu+KOLMBUiFOyj+zGq7+IXwQGl0ppCVDkyzCewyd9LoGe9zAvDxXrLfhLw==",
+      "peer": true,
+      "requires": {
+        "@mapbox/extent": "0.4.0",
+        "@mapbox/geojson-coords": "0.0.2",
+        "rw": "~0.1.4",
+        "traverse": "~0.6.6"
+      }
+    },
+    "@mapbox/geojson-normalize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz",
+      "integrity": "sha512-82V7YHcle8lhgIGqEWwtXYN5cy0QM/OHq3ypGhQTbvHR57DF0vMHMjjVSQKFfVXBe/yWCBZTyOuzvK7DFFnx5Q==",
+      "peer": true
+    },
+    "@mapbox/mapbox-gl-draw": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.3.0.tgz",
+      "integrity": "sha512-B+KWK+dAgzLHMNyKVuuMRfjeSlQ77MhNLdfpQQpbp3pkhnrdmydDe3ixto1Ua78hktNut0WTrAaD8gYu4PVcjA==",
+      "peer": true,
+      "requires": {
+        "@mapbox/geojson-area": "^0.2.2",
+        "@mapbox/geojson-extent": "^1.0.0",
+        "@mapbox/geojson-normalize": "^0.0.1",
+        "@mapbox/point-geometry": "^0.1.0",
+        "hat": "0.0.3",
+        "lodash.isequal": "^4.5.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "peer": true
     },
     "@rollup/plugin-commonjs": {
       "version": "11.0.2",
@@ -1611,6 +4047,16 @@
         "deep-equal": "^1.0.0"
       }
     },
+    "geojson-flatten": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.0.4.tgz",
+      "integrity": "sha512-PpscUXxO6dvvhZxtwuqiI5v+1C/IQYPJRMWoQeaF2oohJgfGYSHKVAe8L+yUqF34PH/hmq9JlwmO+juPw+95/Q==",
+      "peer": true,
+      "requires": {
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.2.5"
+      }
+    },
     "geojson-rbush": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
@@ -1636,6 +4082,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "peer": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1654,6 +4106,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "hat": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "integrity": "sha512-zpImx2GoKXy42fVDSEad2BPKuSQdLcqsCYa48K3zHSzM/ugWuYjLDr8IXxpVuL7uCLHw56eaiLxCRthhOzf5ug==",
+      "peer": true
     },
     "is-arguments": {
       "version": "1.0.4",
@@ -1754,6 +4212,12 @@
       "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
       "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "peer": true
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -1768,6 +4232,12 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "peer": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1898,12 +4368,6 @@
         "acorn": "^7.1.0"
       }
     },
-    "rollup-plugin-peer-deps-external": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
-      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
-      "dev": true
-    },
     "rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -1915,6 +4379,12 @@
         "serialize-javascript": "^4.0.0",
         "terser": "^5.0.0"
       }
+    },
+    "rw": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
+      "integrity": "sha512-vSj3D96kMcjNyqPcp65wBRIDImGSrUuMxngNNxvw8MQaO+aQ6llzRPH7XcJy5zrpb3wU++045+Uz/IDIM684iw==",
+      "peer": true
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -2025,10 +4495,28 @@
         "commander": "2"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
+      "peer": true
+    },
     "turf-jsts": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
+    },
+    "wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==",
+      "peer": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "peerDependencies": {
-    "@mapbox/mapbox-gl-draw": "1.2.0"
+    "@mapbox/mapbox-gl-draw": "1.3.0"
   },
   "dependencies": {
     "@turf/turf": "5.1.6"


### PR DESCRIPTION
Was able to confirm this plugin works with latest Mapbox Draw 1.3.0, so bumping the version peer dependency